### PR TITLE
re-apply fix for precs

### DIFF
--- a/ue/models/blocks/product-recommendations.json
+++ b/ue/models/blocks/product-recommendations.json
@@ -5,7 +5,9 @@
         "id": "product-recommendations",
         "plugins": {
           "da": {
-            "unsafeHTML": "<div class=\"product-recommendations\"><div><div>recid</div><div><p></p></div></div><div><div>currentSku</div><div><p></p></div></div></div>"
+            "name": "product-recommendations",
+            "rows": 2,
+            "columns": 2
           }
         }
       }


### PR DESCRIPTION
in da-blocks-added we fixed precs rendering with this change https://github.com/demo-system-stores/accs-citisignal/pull/22/files#diff-2d840a12096da5acf28f47d1381a1055ecff24a937106ab9c3469e6975b3c959R8-R10

but for some reason it is not applied. re-apply it here.

Test URLs:
- Before: https://main--accs-citisignal--demo-system-stores.aem.live/
- After: https://sirugh-patch-1--accs-citisignal--demo-system-stores.aem.live/
