### PR TITLE
fix: product-recommendations definition now has placeholder value to prevent removal of p tag in some cases

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -163,7 +163,7 @@
           "id": "product-recommendations",
           "plugins": {
             "da": {
-              "unsafeHTML": "<div class=\"product-recommendations\"><div><div>recid</div><div><p></p></div></div><div><div>currentSku</div><div><p></p></div></div></div>"
+              "unsafeHTML": "<div class=\"product-recommendations\"><div><div>recid</div><div><p>PLACEHOLDER</p></div></div><div><div>currentSku</div><div><p>PLACEHOLDER</p></div></div></div>"
             }
           }
         },

--- a/ue/models/blocks/product-recommendations.json
+++ b/ue/models/blocks/product-recommendations.json
@@ -5,7 +5,7 @@
         "id": "product-recommendations",
         "plugins": {
           "da": {
-            "unsafeHTML": "<div class=\"product-recommendations\"><div><div>recid</div><div><p></p></div></div><div><div>currentSku</div><div><p></p></div></div></div>"
+            "unsafeHTML": "<div class=\"product-recommendations\"><div><div>recid</div><div><p>PLACEHOLDER</p></div></div><div><div>currentSku</div><div><p>PLACEHOLDER</p></div></div></div>"
           }
         }
       }


### PR DESCRIPTION
While the `unsafeHTML` defines the structure for DA table with `<p></p>`, it seems an empty p tag can be deleted if the doc editor (DA) has the view open and there is no content.

Reference: https://magento.slack.com/archives/C08TKV0LJJ2/p1758550135341619?thread_ts=1758547198.603099&cid=C08TKV0LJJ2

To prevent the removal of `p` tags, we will add some placeholder text to the initial table.

To repro:

1. Open an empty document in DA
2. Open same doc in UE
3. In UE, create a section and add product-recommendations.
4. Try to modify the values for recid or sku.

With this PR, the above should work. On `main`, it will fail.
