### PR TITLE
force image height on plp and search

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -378,6 +378,8 @@ export default async function decorate(block) {
           onSearchResult: (results) => {
             searchResult.style.display = results.length > 0 ? 'block' : 'none';
           },
+          imageWidth: 400,
+          imageHeight: 311,
           slots: {
             ProductImage: (ctx) => {
               const { product, defaultImageProps } = ctx;
@@ -389,8 +391,8 @@ export default async function decorate(block) {
                 imageProps: defaultImageProps,
                 wrapper: anchorWrapper,
                 params: {
-                  width: defaultImageProps.width,
-                  height: defaultImageProps.height,
+                  width: 400,
+                  height: 311,
                 },
               });
             },

--- a/blocks/product-list-page/product-list-page.js
+++ b/blocks/product-list-page/product-list-page.js
@@ -139,6 +139,8 @@ export default async function decorate(block) {
     // Product List
     provider.render(SearchResults, {
       routeProduct: (product) => rootLink(`/products/${product.urlKey}/${product.sku}`),
+      imageWidth: 400,
+      imageHeight: 311,
       slots: {
         ProductImage: (ctx) => {
           const { product, defaultImageProps } = ctx;
@@ -150,8 +152,8 @@ export default async function decorate(block) {
             imageProps: defaultImageProps,
             wrapper: anchorWrapper,
             params: {
-              width: defaultImageProps.width,
-              height: defaultImageProps.height,
+              width: 400,
+              height: 311,
             },
           });
         },


### PR DESCRIPTION
TODO: The below doesn't resolve the issue for the entire site. This is because your dataset has images with varying aspect ratios across the board. Phones are 400x311. Accessories are 400x400 but also there's at least one item that has like, [900 x 450 image](http://localhost:3000/products/superpro-series-for-droidview-1-2/SuperPro12). 

I'd suggest redoing the source data set with consistent image sizes across the board. Then you can apply that aspect ratio to your "template" blocks.

Otherwise you will have to have conditionals at least "if x category, use NxM aspect ratio" which is not great.

-----

Regarding PLP and search images being "stretched". This is because the actual images are 400x311 intrinsic. You have default of 400 x 450 being applied.

<img width="1329" height="860" alt="image" src="https://github.com/user-attachments/assets/8a48d041-1aab-4fa5-8c08-485dc9d53dcd" />

with the hardcoded width/height applied:

<img width="1276" height="940" alt="image" src="https://github.com/user-attachments/assets/57b65081-2366-49e2-bb2a-71a6cfd55fa6" />

This is one way to solve this problem. Not necessarily "the best" or most robust, since if you change content sizes in backend you will also have to apply the update in the UI here.
